### PR TITLE
Fix: Use dynamic path for permission-mcp-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+.env
+.nyc_output
+coverage
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+dist
+.DS_Store
+*.log
+usercontent/

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,25 @@
-# Slack App Configuration
+# Slack App Configuration (Required)
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_APP_TOKEN=xapp-your-app-token
 SLACK_SIGNING_SECRET=your-signing-secret
 
-# Claude Code Configuration
-ANTHROPIC_API_KEY=your-anthropic-api-key
-
-# Working Directory Configuration
-# Base directory for relative paths (e.g., /Users/username/Code/)
-# If set, you can use "cwd project-name" instead of full paths
-BASE_DIRECTORY=/Users/username/Code/
-
-# Optional: Use third-party providers
+# Claude Code Configuration (Optional - only needed if you don't use a Claude subscription)
+# ANTHROPIC_API_KEY=your-anthropic-api-key
 # CLAUDE_CODE_USE_BEDROCK=1
 # CLAUDE_CODE_USE_VERTEX=1
 
-# Development
+# GitHub App Integration (Optional - Recommended for GitHub access)
+# GITHUB_APP_ID=123456
+# GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYour private key content here...\n-----END RSA PRIVATE KEY-----"
+# GITHUB_INSTALLATION_ID=12345678
+
+# GitHub Token Integration (Optional - Legacy fallback)
+# GITHUB_TOKEN=ghp_your_personal_access_token
+
+# Working Directory Configuration (Optional)
+# Base directory for relative paths (e.g., /Users/username/Code/)
+# If set, you can use "cwd project-name" instead of full paths
+# BASE_DIRECTORY=/Users/username/Code/
+
+# Development Configuration (Optional)
 # DEBUG=true

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 # Testing
 coverage/
 .nyc_output/
+
+usercontent/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,33 @@ The project includes a pre-configured `mcp-servers.json` file that automatically
 - Commit history and diff viewing
 - Organization and team management (with proper permissions)
 
+#### Automatic Token Refresh
+
+The bot automatically handles GitHub App token refresh to ensure continuous operation:
+
+**Features:**
+- **Automatic Refresh**: Tokens are refreshed 5 minutes before expiry or at 50% of their lifetime (whichever is shorter)
+- **Background Processing**: Token refresh happens in the background without interrupting operations
+- **Git Credentials Update**: Automatically updates git credentials and environment variables when tokens are refreshed
+- **Retry Logic**: If token refresh fails, the system will retry every 2 minutes until successful
+- **Graceful Degradation**: Continues to use existing tokens during refresh attempts
+
+**Implementation Details:**
+- Tokens are cached until expiry to minimize API calls
+- Uses Node.js timers to schedule refresh operations
+- Updates both `.git-credentials` file and git global configuration
+- Exports `GITHUB_TOKEN` environment variable for child processes
+- Automatic cleanup on application shutdown
+
+**Monitoring:**
+The bot logs all token refresh activities:
+```
+GitHub App token refresh scheduled for 2024-01-01T12:00:00.000Z (in 55 minutes)
+Background refresh of GitHub App installation token starting
+GitHub App installation token refreshed successfully in background
+Git credentials updated successfully with refreshed GitHub App token
+```
+
 #### Git CLI Authentication
 
 The bot automatically handles GitHub authentication for Git CLI operations performed by Claude Code. When Claude executes Git commands that require GitHub access (push, pull, clone from private repositories), the bot provides the appropriate authentication:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,10 @@ The bot allows users to interact with Claude Code through Slack, providing real-
 - **External Tools**: Extends Claude's capabilities with external MCP servers
 - **Multiple Server Types**: Supports stdio, SSE, and HTTP MCP servers
 - **Auto-Configuration**: Loads servers from `mcp-servers.json` automatically
+- **Default Configuration**: Pre-configured with filesystem and GitHub servers
 - **Tool Management**: All MCP tools are allowed by default with `mcp__serverName__toolName` pattern
 - **Runtime Management**: Reload configuration without restarting the bot
-- **Popular Integrations**: Filesystem access, GitHub API, database connections, web search
+- **Popular Integrations**: Filesystem access, GitHub API (via token), database connections, web search
 
 ## Environment Configuration
 
@@ -82,6 +83,9 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 ```env
 # Working Directory Configuration
 BASE_DIRECTORY=/Users/username/Code/
+
+# GitHub Integration (for MCP)
+GITHUB_TOKEN=ghp_your_personal_access_token
 
 # Third-party API Providers
 CLAUDE_CODE_USE_BEDROCK=1
@@ -167,6 +171,77 @@ Bot: ✅ MCP configuration reloaded successfully.
 User: @ClaudeBot list all TODO comments in the project
 Bot: [Uses mcp__filesystem tools to search files]
 ```
+
+### GitHub Integration
+
+GitHub integration is provided through the MCP GitHub server using a personal access token:
+
+#### Setup
+1. **Generate a GitHub Personal Access Token:**
+
+   **Step-by-step instructions:**
+   
+   a. **Navigate to GitHub Settings:**
+      - Go to [github.com](https://github.com) and sign in
+      - Click your profile picture in the top right corner
+      - Select "Settings" from the dropdown menu
+   
+   b. **Access Developer Settings:**
+      - In the left sidebar, scroll down and click "Developer settings"
+      - Click "Personal access tokens"
+      - Select "Tokens (classic)"
+   
+   c. **Generate New Token:**
+      - Click "Generate new token (classic)"
+      - You may be prompted to confirm your password
+   
+   d. **Configure Token:**
+      - **Note**: Give it a descriptive name like "Claude Code Slack Bot"
+      - **Expiration**: Choose an appropriate expiration (90 days, 1 year, or no expiration)
+      - **Select scopes** based on your needs:
+        - ✅ `repo` - Full control of private repositories (includes all repo permissions)
+        - ✅ `read:org` - Read organization membership and team membership
+        - ✅ `read:user` - Read user profile data
+        - ✅ `user:email` - Access user email addresses (read-only)
+   
+   e. **Generate and Save Token:**
+      - Click "Generate token" at the bottom
+      - **Important**: Copy the token immediately - you won't be able to see it again
+      - Store it securely (password manager, secure notes, etc.)
+   
+   **Token Format**: The token will look like `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+   **Security Notes:**
+   - Treat this token like a password - never share it publicly
+   - Don't commit it to version control
+   - Use environment variables or secure secret management
+   - Consider setting an expiration date for better security
+   - You can regenerate the token anytime if compromised
+
+   **Permission Explanation:**
+   - `repo`: Grants full access to repositories (read, write, admin)
+   - `read:org`: Allows reading organization membership and team membership
+   - `read:user`: Allows reading basic user profile information
+   - `user:email`: Allows reading user email addresses
+
+2. Add the token to your environment:
+   ```env
+   GITHUB_TOKEN=ghp_your_personal_access_token
+   ```
+
+3. **Configure MCP Server:**
+   The project includes a pre-configured `mcp-servers.json` file that automatically sets up:
+   - **Filesystem server**: Provides access to the working directory
+   - **GitHub server**: Activated when `GITHUB_TOKEN` environment variable is provided
+   
+   For Docker deployment, no additional MCP configuration is needed. For local development, you can modify `mcp-servers.json` as needed.
+
+#### Available GitHub Features
+- Repository browsing and file access
+- Pull request management
+- Issue tracking
+- Code search and analysis
+- Commit history and diff viewing
 
 ## Development
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:18-alpine
 
 # Install system dependencies including bash and common shell utilities
-RUN apk add --no-cache git curl bash coreutils findutils grep sed github-cli
+RUN apk add --no-cache git curl bash coreutils findutils grep sed github-cli openssl
 
 # Install ripgrep (required by Claude Code SDK)
 RUN curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz && \
@@ -21,6 +21,10 @@ RUN npm ci
 
 # Install tsx globally
 RUN npm install -g tsx
+
+# Install MCP servers globally for GitHub app integration
+RUN npm install -g @modelcontextprotocol/server-filesystem@latest
+RUN npm install -g @modelcontextprotocol/server-github@latest  
 
 # Copy source code
 COPY . .
@@ -57,4 +61,4 @@ USER nodejs
 EXPOSE $PORT
 
 # Start both the healthcheck server and the main application
-CMD ["/bin/bash", "-c", "/usr/local/bin/setup-git-auth.sh node healthcheck.js & npm run start"]
+CMD ["/bin/bash", "-c", "source /usr/local/bin/setup-git-auth.sh && node healthcheck.js & npm run start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,5 @@ USER nodejs
 # Expose the port
 EXPOSE $PORT
 
-# Start the application with Git authentication setup
-CMD ["/usr/local/bin/setup-git-auth.sh", "npm", "run", "start"]
+# Start both the healthcheck server and the main application
+CMD ["/bin/bash", "-c", "/usr/local/bin/setup-git-auth.sh node healthcheck.js & npm run start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Use Node.js LTS version
+FROM node:18-alpine
+
+# Install system dependencies including bash and common shell utilities
+RUN apk add --no-cache git curl bash coreutils findutils grep sed github-cli
+
+# Install ripgrep (required by Claude Code SDK)
+RUN curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz && \
+    tar xf ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz && \
+    mv ripgrep-14.1.1-x86_64-unknown-linux-musl/rg /usr/local/bin/ && \
+    rm -rf ripgrep-14.1.1-*
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Install tsx globally
+RUN npm install -g tsx
+
+# Copy source code
+COPY . .
+
+# Copy Claude Code settings to home directory for default permissions
+COPY claude-code-settings.json /home/nodejs/.claude/settings.json
+
+# Copy and make the setup script executable
+COPY setup-git-auth.sh /usr/local/bin/setup-git-auth.sh
+RUN chmod +x /usr/local/bin/setup-git-auth.sh
+
+# Create the user content directory
+RUN mkdir -p /usercontent
+
+# Create non-root user with bash shell
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nodejs -u 1001 -s /bin/bash
+
+# Change ownership of directories
+RUN chown -R nodejs:nodejs /app
+RUN chown -R nodejs:nodejs /usercontent
+RUN chown -R nodejs:nodejs /home/nodejs/.claude
+RUN chown nodejs:nodejs /home/nodejs/.claude/settings.json
+
+# Set environment variable for base directory
+ENV BASE_DIRECTORY=/usercontent
+
+USER nodejs
+
+# Configure Git to use token-based authentication for GitHub
+# This will be set up at runtime when GITHUB_TOKEN is available
+
+# Expose the port
+EXPOSE $PORT
+
+# Start the application with Git authentication setup
+CMD ["/usr/local/bin/setup-git-auth.sh", "npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -73,10 +73,20 @@ SLACK_SIGNING_SECRET=your-signing-secret
 
 # Claude Code Configuration
 # This is only needed if you don't use a Claude subscription
-
 # ANTHROPIC_API_KEY=your-anthropic-api-key
 # CLAUDE_CODE_USE_BEDROCK=1
 # CLAUDE_CODE_USE_VERTEX=1
+
+# GitHub App Integration (Optional - Recommended for GitHub access)
+# GITHUB_APP_ID=123456
+# GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYour private key content here...\n-----END RSA PRIVATE KEY-----"
+# GITHUB_INSTALLATION_ID=12345678
+
+# GitHub Token Integration (Optional - Legacy fallback)
+# GITHUB_TOKEN=ghp_your_personal_access_token
+
+# Working Directory Configuration (Optional)
+# BASE_DIRECTORY=/Users/username/Code/
 ```
 
 ### 5. Run the Bot
@@ -227,9 +237,90 @@ All MCP tools are automatically allowed and follow the pattern: `mcp__serverName
 
 ### GitHub Integration
 
-The bot supports GitHub integration through the MCP GitHub server using a personal access token. This provides access to repositories, pull request management, and code analysis through Claude's MCP tools.
+The bot supports GitHub integration through the MCP GitHub server using **GitHub Apps** (recommended) or personal access tokens (legacy). This provides access to repositories, pull request management, and code analysis through Claude's MCP tools.
 
-#### Setting up GitHub Integration
+#### Setting up GitHub Integration with GitHub Apps (Recommended)
+
+GitHub Apps provide better security and granular permissions compared to personal access tokens. They also provide higher rate limits and institutional identity.
+
+1. **Create a GitHub App:**
+
+   **Step-by-step instructions:**
+   
+   a. **Navigate to GitHub Settings:**
+      - Go to [github.com](https://github.com) and sign in
+      - Click your profile picture in the top right corner
+      - Select "Settings" from the dropdown menu
+   
+   b. **Access Developer Settings:**
+      - In the left sidebar, scroll down and click "Developer settings"
+      - Click "GitHub Apps"
+      - Click "New GitHub App"
+   
+   c. **Configure the GitHub App:**
+      - **GitHub App name**: "Claude Code Slack Bot" (or your preferred name)
+      - **Homepage URL**: Your organization's website or the repository URL
+      - **Webhook URL**: Leave blank (not used for this integration)
+      - **Webhook secret**: Leave blank
+      - **Permissions**: Select the following repository permissions:
+        - ✅ `Contents` - Read & Write (for reading and modifying files)
+        - ✅ `Issues` - Read & Write (for issue management)
+        - ✅ `Pull requests` - Read & Write (for PR management)
+        - ✅ `Metadata` - Read (for basic repository information)
+        - ✅ `Actions` - Read (optional, for viewing CI/CD status)
+      - **Organization permissions** (optional):
+        - ✅ `Members` - Read (for team information)
+      - **User permissions**: None required
+      - **Subscribe to events**: None required (we don't use webhooks)
+      - **Where can this GitHub App be installed?**: Choose based on your needs
+        - "Only on this account" for personal use
+        - "Any account" if you plan to share the app
+   
+   d. **Create the App:**
+      - Click "Create GitHub App"
+      - You'll be redirected to the app's settings page
+   
+   e. **Generate Private Key:**
+      - Scroll down to "Private keys" section
+      - Click "Generate a private key"
+      - Download the `.pem` file and store it securely
+   
+   f. **Note the App ID:**
+      - At the top of the app settings page, note the "App ID" (e.g., 123456)
+
+2. **Install the GitHub App:**
+
+   a. **Install on Repositories:**
+      - Go to the "Install App" tab in your GitHub App settings
+      - Click "Install" next to your account/organization
+      - Choose "All repositories" or "Selected repositories" based on your needs
+      - Complete the installation
+   
+   b. **Note the Installation ID:**
+      - After installation, you'll see the installation URL
+      - The Installation ID is in the URL: `https://github.com/settings/installations/12345678`
+      - Note this number (e.g., 12345678)
+
+3. **Configure Environment Variables:**
+   ```env
+   # GitHub App Configuration (Recommended)
+   GITHUB_APP_ID=123456
+   GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+   MIIEpAIBAAKCAQEA...
+   (your private key content here)
+   ...
+   -----END RSA PRIVATE KEY-----"
+   GITHUB_INSTALLATION_ID=12345678
+   ```
+
+   **Important Notes:**
+   - The private key should include the full PEM format with line breaks
+   - Store the private key securely and never commit it to version control
+   - The bot will automatically discover installations if INSTALLATION_ID is not set
+
+#### Legacy Setup with Personal Access Tokens (Fallback)
+
+If you prefer or need to use personal access tokens instead of GitHub Apps:
 
 1. **Create a Personal Access Token:**
    
@@ -280,16 +371,28 @@ The bot supports GitHub integration through the MCP GitHub server using a person
 
 2. **Configure Environment Variables:**
    ```env
-   # GitHub Token for MCP
+   # GitHub Token for MCP (Legacy fallback)
    GITHUB_TOKEN=ghp_your_personal_access_token
    ```
+
+#### Authentication Priority
+
+The bot will automatically use GitHub App authentication when configured, and fall back to personal access tokens if GitHub App settings are not available.
+
+#### Advantages of GitHub Apps over Personal Tokens
+- **Better Security**: Apps have granular permissions instead of broad user-level access
+- **Institutional Identity**: Actions appear as the app, not a personal user
+- **No User Dependency**: Doesn't depend on a specific user's account remaining active
+- **Audit Trail**: Better tracking of automated actions
+- **Rate Limits**: Higher rate limits for API requests
+- **Revocable**: Easy to revoke access without affecting user's personal tokens
 
 3. **Configure MCP Server:**
    The Docker container includes a pre-configured `mcp-servers.json` file that automatically sets up:
    - **Filesystem server**: Provides access to the `/usercontent` directory
-   - **GitHub server**: Activated when `GITHUB_TOKEN` environment variable is provided
+   - **GitHub server**: Uses GitHub App authentication when configured, or falls back to `GITHUB_TOKEN`
    
-   No additional MCP configuration is needed for Docker deployment.
+   No additional MCP configuration is needed for Docker deployment. The bot will automatically use GitHub App authentication when available.
 
 ### Using AWS Bedrock
 Set these environment variables:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,72 @@ All MCP tools are automatically allowed and follow the pattern: `mcp__serverName
 
 ## Advanced Configuration
 
+### GitHub Integration
+
+The bot supports GitHub integration through the MCP GitHub server using a personal access token. This provides access to repositories, pull request management, and code analysis through Claude's MCP tools.
+
+#### Setting up GitHub Integration
+
+1. **Create a Personal Access Token:**
+   
+   **Step-by-step instructions:**
+   
+   a. **Navigate to GitHub Settings:**
+      - Go to [github.com](https://github.com) and sign in
+      - Click your profile picture in the top right corner
+      - Select "Settings" from the dropdown menu
+   
+   b. **Access Developer Settings:**
+      - In the left sidebar, scroll down and click "Developer settings"
+      - Click "Personal access tokens"
+      - Select "Tokens (classic)"
+   
+   c. **Generate New Token:**
+      - Click "Generate new token (classic)"
+      - You may be prompted to confirm your password
+   
+   d. **Configure Token:**
+      - **Note**: Give it a descriptive name like "Claude Code Slack Bot"
+      - **Expiration**: Choose an appropriate expiration (90 days, 1 year, or no expiration)
+      - **Select scopes** based on your needs:
+        - ✅ `repo` - Full control of private repositories (includes all repo permissions)
+        - ✅ `read:org` - Read organization membership and team membership
+        - ✅ `read:user` - Read user profile data
+        - ✅ `user:email` - Access user email addresses (read-only)
+   
+   e. **Generate and Save Token:**
+      - Click "Generate token" at the bottom
+      - **Important**: Copy the token immediately - you won't be able to see it again
+      - Store it securely (password manager, secure notes, etc.)
+   
+   **Token Format**: The token will look like `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
+   **Security Notes:**
+   - Treat this token like a password - never share it publicly
+   - Don't commit it to version control
+   - Use environment variables or secure secret management
+   - Consider setting an expiration date for better security
+   - You can regenerate the token anytime if compromised
+
+   **Permission Explanation:**
+   - `repo`: Grants full access to repositories (read, write, admin)
+   - `read:org`: Allows reading organization membership and team membership
+   - `read:user`: Allows reading basic user profile information
+   - `user:email`: Allows reading user email addresses
+
+2. **Configure Environment Variables:**
+   ```env
+   # GitHub Token for MCP
+   GITHUB_TOKEN=ghp_your_personal_access_token
+   ```
+
+3. **Configure MCP Server:**
+   The Docker container includes a pre-configured `mcp-servers.json` file that automatically sets up:
+   - **Filesystem server**: Provides access to the `/usercontent` directory
+   - **GitHub server**: Activated when `GITHUB_TOKEN` environment variable is provided
+   
+   No additional MCP configuration is needed for Docker deployment.
+
 ### Using AWS Bedrock
 Set these environment variables:
 ```env

--- a/claude-code-settings.json
+++ b/claude-code-settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git clone:*)",
+      "Bash(git pull:*)",
+      "Bash(git push:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git commit:*)",
+      "Bash(git add:*)",
+      "Bash(git status:*)",
+      "Bash(gh pr:*)",
+      "FileSystem(read:/usercontent/*)",
+      "FileSystem(write:/usercontent/*)",
+      "FileSystem(list:/usercontent/*)",
+      "FileSystem(delete:/usercontent/*)",
+      "FileSystem(createDirectory:/usercontent/*)",
+      "Edit(//usercontent/**)",
+      "MultiEdit(//usercontent/**)",
+      "Write(//usercontent/**)"
+    ],
+    "additionalDirectories": ["/usercontent"]
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - DEBUG=${DEBUG:-false}
       - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-0}
       - CLAUDE_CODE_USE_VERTEX=${CLAUDE_CODE_USE_VERTEX:-0}
-      # GitHub Token for MCP
+      # GitHub App Configuration for MCP
+      - GITHUB_APP_ID=${GITHUB_APP_ID}
+      - GITHUB_PRIVATE_KEY=${GITHUB_PRIVATE_KEY}
+      - GITHUB_INSTALLATION_ID=${GITHUB_INSTALLATION_ID}
+      # Legacy GitHub Token (fallback)
       - GITHUB_TOKEN=${GITHUB_TOKEN}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  claude-code-slack-bot:
+    build: .
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    volumes:
+      - ./user-content:/usercontent
+    environment:
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
+      - SLACK_APP_TOKEN=${SLACK_APP_TOKEN}
+      - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - BASE_DIRECTORY=/usercontent
+      - PORT=${PORT:-3000}
+      - DEBUG=${DEBUG:-false}
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-0}
+      - CLAUDE_CODE_USE_VERTEX=${CLAUDE_CODE_USE_VERTEX:-0}
+      # GitHub Token for MCP
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+    restart: unless-stopped

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,32 @@
+const http = require('http');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health' || req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok', timestamp: new Date().toISOString() }));
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Healthcheck server listening on port ${port}`);
+});
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM, shutting down healthcheck server');
+  server.close(() => {
+    process.exit(0);
+  });
+});
+
+process.on('SIGINT', () => {
+  console.log('Received SIGINT, shutting down healthcheck server');
+  server.close(() => {
+    process.exit(0);
+  });
+});

--- a/mcp-servers.example.json
+++ b/mcp-servers.example.json
@@ -9,17 +9,22 @@
       ]
     },
     "github": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "ghcr.io/github/github-mcp-server"
+      ],
       "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "dynamically_provided_by_github_app"
       }
     },
     "git": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-git", "/usercontent"],
       "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "dynamically_provided_by_github_app"
       }
     },
     "postgres": {

--- a/mcp-servers.example.json
+++ b/mcp-servers.example.json
@@ -5,14 +5,21 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-filesystem",
-        "/Users/username/Code/"
+        "/usercontent"
       ]
     },
     "github": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_TOKEN": "your-github-token"
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    },
+    "git": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-git", "/usercontent"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "postgres": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@anthropic-ai/claude-code": "^1.0.119",
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@slack/bolt": "^4.4.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node-fetch": "^2.6.12",
         "dotenv": "^16.6.0",
+        "jsonwebtoken": "^9.0.2",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -817,6 +819,7 @@
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
       "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
@@ -1652,6 +1655,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.35",
-        "@modelcontextprotocol/sdk": "^1.13.2",
+        "@anthropic-ai/claude-code": "^1.0.119",
+        "@modelcontextprotocol/sdk": "^1.18.1",
         "@slack/bolt": "^4.4.0",
         "@types/node-fetch": "^2.6.12",
         "dotenv": "^16.6.0",
@@ -23,10 +23,10 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.35.tgz",
-      "integrity": "sha512-rQr03moVxUZSR9hZGHXatjukxmgK9VoihiVG/lkUWFb6NDxhG+EZB+jSY2gtTsxJwnE1pQciLvOPVI/UxXo4TA==",
-      "hasInstallScript": true,
+      "version": "1.0.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.119.tgz",
+      "integrity": "sha512-0SxTgt7Htr2okxL2Uk0Mv5eB8JxBrRCZCdtTNwuYC/OBl2F7UDM8YFtIwHz97ygCoJw49j7SL6s+/MIZGaEzrA==",
+      "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"
       },
@@ -641,15 +641,17 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
-      "integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.1.tgz",
+      "integrity": "sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "@anthropic-ai/claude-code": "^1.0.119",
     "@modelcontextprotocol/sdk": "^1.18.1",
     "@slack/bolt": "^4.4.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node-fetch": "^2.6.12",
     "dotenv": "^16.6.0",
+    "jsonwebtoken": "^9.0.2",
     "node-fetch": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.35",
-    "@modelcontextprotocol/sdk": "^1.13.2",
+    "@anthropic-ai/claude-code": "^1.0.119",
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "@slack/bolt": "^4.4.0",
     "@types/node-fetch": "^2.6.12",
     "dotenv": "^16.6.0",

--- a/setup-git-auth.sh
+++ b/setup-git-auth.sh
@@ -1,28 +1,148 @@
 #!/bin/bash
 
-# Setup Git authentication using GITHUB_TOKEN
-if [ -n "$GITHUB_TOKEN" ]; then
-    echo "Setting up Git authentication with GitHub token..."
+# Function to generate GitHub App JWT token
+generate_github_app_jwt() {
+    local app_id="$1"
+    local private_key="$2"
     
-    # Configure Git to use the token as credentials
-    git config --global credential.helper store
+    # Generate JWT payload
+    local now=$(date +%s)
+    local iat=$((now - 60))
+    local exp=$((now + 600))  # 10 minutes
     
-    # Set up the credential file with the token
-    echo "https://${GITHUB_TOKEN}:x-oauth-basic@github.com" > ~/.git-credentials
+    # Create JWT header (base64url encoded)
+    local header='{"alg":"RS256","typ":"JWT"}'
+    local header_b64=$(echo -n "$header" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
     
-    # Alternative approach: Configure Git to use token directly
-    git config --global credential.https://github.com.username "$GITHUB_TOKEN"
-    git config --global credential.https://github.com.helper store
+    # Create JWT payload (base64url encoded)
+    local payload="{\"iat\":$iat,\"exp\":$exp,\"iss\":\"$app_id\"}"
+    local payload_b64=$(echo -n "$payload" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+    
+    # Create signature
+    local signing_input="${header_b64}.${payload_b64}"
+    
+    # Write private key to temp file for openssl
+    local temp_key=$(mktemp)
+    echo "$private_key" > "$temp_key"
+    
+    # Generate signature using openssl
+    local signature=$(echo -n "$signing_input" | openssl dgst -sha256 -sign "$temp_key" | base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+    
+    # Clean up temp file
+    rm "$temp_key"
+    
+    # Return JWT
+    echo "${signing_input}.${signature}"
+}
+
+# Function to get GitHub App installation token
+get_github_app_token() {
+    local app_id="$1"
+    local private_key="$2" 
+    local installation_id="$3"
+    
+    echo "Generating GitHub App installation token..." >&2
+    
+    # Generate JWT
+    local jwt=$(generate_github_app_jwt "$app_id" "$private_key")
+    if [ $? -ne 0 ] || [ -z "$jwt" ]; then
+        echo "Error: Failed to generate GitHub App JWT"
+        return 1
+    fi
+    
+    # Get installation token from GitHub API
+    local response=$(curl -s -X POST \
+        -H "Authorization: Bearer $jwt" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "User-Agent: Claude-Code-Slack-Bot/1.0.0" \
+        "https://api.github.com/app/installations/$installation_id/access_tokens")
+    
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to call GitHub API"
+        return 1
+    fi
+    
+    # Extract token from JSON response
+    local token=$(echo "$response" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
+    
+    if [ -z "$token" ]; then
+        echo "Error: Failed to extract token from GitHub API response"
+        echo "API Response: $response"
+        return 1
+    fi
+    
+    echo "$token"
+}
+
+# Function to setup Git authentication with a token
+setup_git_auth_with_token() {
+    local token="$1"
+    local source="$2"
+    local is_github_app="$3"
+    
+    echo "Setting up Git authentication with $source..."
+    
+    # Clean the token by removing any newlines or whitespace
+    local clean_token=$(echo "$token" | tr -d '\n\r' | xargs)
+    
+    # Export the token for use by child processes (like Claude's git commands)
+    export GITHUB_TOKEN="$clean_token"
+    
+    # Use different authentication format based on token type
+    if [ "$is_github_app" = "true" ]; then
+        # GitHub App installation tokens use x-access-token format
+        echo "https://x-access-token:${clean_token}@github.com" > ~/.git-credentials
+        git config --global url."https://x-access-token:${clean_token}@github.com/".insteadOf "https://github.com/"
+        echo "Using GitHub App installation token format (x-access-token)"
+    else
+        # Personal access tokens use the token directly or with x-oauth-basic
+        echo "https://${clean_token}:x-oauth-basic@github.com" > ~/.git-credentials
+        git config --global url."https://${clean_token}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+        echo "Using personal access token format (x-oauth-basic)"
+    fi
+    
+    # Configure Git credential helper specifically for GitHub
+    git config --global credential.https://github.com.username "$clean_token"
     
     # Set Git user for commits (optional but recommended)
     BOT_NAME="${BOT_NAME:-claudebot}"
     git config --global user.name "$BOT_NAME"
     git config --global user.email "$BOT_NAME@anthropic.com"
     
-    echo "Git authentication configured successfully"
-else
-    echo "Warning: GITHUB_TOKEN not found. Git authentication for private repositories will not work."
-fi
+    echo "Git authentication configured successfully with $source"
+    echo "GITHUB_TOKEN exported for child processes"
+}
 
-# Start the application
-exec "$@"
+# Main authentication logic
+setup_git_authentication() {
+    # First priority: Check if GITHUB_TOKEN is already set
+    if [ -n "$GITHUB_TOKEN" ]; then
+        setup_git_auth_with_token "$GITHUB_TOKEN" "GitHub token from environment" "false"
+        return
+    fi
+    
+    # Second priority: Try to get GitHub App installation token
+    if [ -n "$GITHUB_APP_ID" ] && [ -n "$GITHUB_PRIVATE_KEY" ] && [ -n "$GITHUB_INSTALLATION_ID" ]; then
+        echo "GitHub App credentials found, attempting to generate installation token..."
+        
+        local app_token
+        app_token=$(get_github_app_token "$GITHUB_APP_ID" "$GITHUB_PRIVATE_KEY" "$GITHUB_INSTALLATION_ID")
+        
+        if [ $? -eq 0 ] && [ -n "$app_token" ]; then
+            # Export the token as GITHUB_TOKEN for the Node.js application
+            export GITHUB_TOKEN="$app_token"
+            setup_git_auth_with_token "$app_token" "GitHub App installation token" "true"
+            return
+        else
+            echo "Warning: Failed to generate GitHub App installation token, falling back to no authentication"
+        fi
+    fi
+    
+    # No authentication available
+    echo "Warning: No GitHub authentication configured."
+    echo "Set GITHUB_TOKEN or configure GitHub App (GITHUB_APP_ID, GITHUB_PRIVATE_KEY, GITHUB_INSTALLATION_ID)"
+    echo "Git authentication for private repositories will not work."
+}
+
+# Run the authentication setup
+setup_git_authentication

--- a/setup-git-auth.sh
+++ b/setup-git-auth.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Setup Git authentication using GITHUB_TOKEN
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Setting up Git authentication with GitHub token..."
+    
+    # Configure Git to use the token as credentials
+    git config --global credential.helper store
+    
+    # Set up the credential file with the token
+    echo "https://${GITHUB_TOKEN}:x-oauth-basic@github.com" > ~/.git-credentials
+    
+    # Alternative approach: Configure Git to use token directly
+    git config --global credential.https://github.com.username "$GITHUB_TOKEN"
+    git config --global credential.https://github.com.helper store
+    
+    # Set Git user for commits (optional but recommended)
+    BOT_NAME="${BOT_NAME:-claudebot}"
+    git config --global user.name "$BOT_NAME"
+    git config --global user.email "$BOT_NAME@anthropic.com"
+    
+    echo "Git authentication configured successfully"
+else
+    echo "Warning: GITHUB_TOKEN not found. Git authentication for private repositories will not work."
+fi
+
+# Start the application
+exec "$@"

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -61,7 +61,7 @@ export class ClaudeHandler {
     }
 
     // Add MCP server configuration if available
-    const mcpServers = this.mcpManager.getServerConfiguration();
+    const mcpServers = await this.mcpManager.getServerConfiguration();
     
     // Add permission prompt server if we have Slack context
     if (slackContext) {

--- a/src/claude-handler.ts
+++ b/src/claude-handler.ts
@@ -2,6 +2,7 @@ import { query, type SDKMessage } from '@anthropic-ai/claude-code';
 import { ConversationSession } from './types';
 import { Logger } from './logger';
 import { McpManager, McpServerConfig } from './mcp-manager';
+import * as path from 'path';
 
 export class ClaudeHandler {
   private sessions: Map<string, ConversationSession> = new Map();
@@ -41,13 +42,18 @@ export class ClaudeHandler {
   ): AsyncGenerator<SDKMessage, void, unknown> {
     const options: any = {
       outputFormat: 'stream-json',
+      // Enable permission prompts when we have Slack context
       permissionMode: slackContext ? 'default' : 'bypassPermissions',
     };
 
     // Add permission prompt tool if we have Slack context
     if (slackContext) {
       options.permissionPromptToolName = 'mcp__permission-prompt__permission_prompt';
-      this.logger.debug('Added permission prompt tool for Slack integration', slackContext);
+      this.logger.debug('Configured permission prompts for Slack integration', {
+        channel: slackContext.channel,
+        user: slackContext.user,
+        hasThread: !!slackContext.threadTs
+      });
     }
 
     if (workingDirectory) {
@@ -62,7 +68,7 @@ export class ClaudeHandler {
       const permissionServer = {
         'permission-prompt': {
           command: 'npx',
-          args: ['tsx', '/Users/marcelpociot/Experiments/claude-code-slack/src/permission-mcp-server.ts'],
+          args: ['tsx', path.join(__dirname, 'permission-mcp-server.ts')],
           env: {
             SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
             SLACK_CONTEXT: JSON.stringify(slackContext)
@@ -83,7 +89,7 @@ export class ClaudeHandler {
       // Allow all MCP tools by default, plus permission prompt tool
       const defaultMcpTools = this.mcpManager.getDefaultAllowedTools();
       if (slackContext) {
-        defaultMcpTools.push('mcp__permission-prompt');
+        defaultMcpTools.push('mcp__permission-prompt__permission_prompt');
       }
       if (defaultMcpTools.length > 0) {
         options.allowedTools = defaultMcpTools;
@@ -94,6 +100,7 @@ export class ClaudeHandler {
         servers: Object.keys(options.mcpServers),
         allowedTools: defaultMcpTools,
         hasSlackContext: !!slackContext,
+        permissionMode: options.permissionMode,
       });
     }
 
@@ -106,10 +113,13 @@ export class ClaudeHandler {
 
     this.logger.debug('Claude query options', options);
 
+    if (abortController) {
+      options.abortController = abortController;
+    }
+
     try {
       for await (const message of query({
         prompt,
-        abortController: abortController || new AbortController(),
         options,
       })) {
         if (message.type === 'system' && message.subtype === 'init') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,12 @@ export const config = {
     useVertex: process.env.CLAUDE_CODE_USE_VERTEX === '1',
   },
   baseDirectory: process.env.BASE_DIRECTORY || '',
+  github: {
+    appId: process.env.GITHUB_APP_ID || '',
+    privateKey: process.env.GITHUB_PRIVATE_KEY || '',
+    installationId: process.env.GITHUB_INSTALLATION_ID || '',
+    token: process.env.GITHUB_TOKEN || '',
+  },
   debug: process.env.DEBUG === 'true' || process.env.NODE_ENV === 'development',
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export function validateConfig() {
     'SLACK_BOT_TOKEN',
     'SLACK_APP_TOKEN',
     'SLACK_SIGNING_SECRET',
+    'ANTHROPIC_API_KEY',
   ];
 
   const missing = required.filter((key) => !process.env[key]);

--- a/src/git-cli-auth.ts
+++ b/src/git-cli-auth.ts
@@ -1,0 +1,63 @@
+import { getGitHubTokenForCLI } from './github-auth.js';
+import { Logger } from './logger.js';
+
+const logger = new Logger('GitCLIAuth');
+
+export interface GitEnvironmentVariables {
+  GITHUB_TOKEN?: string;
+  [key: string]: string | undefined;
+}
+
+export async function getGitEnvironmentVariables(): Promise<GitEnvironmentVariables> {
+  const env: GitEnvironmentVariables = {};
+  
+  try {
+    const githubToken = await getGitHubTokenForCLI();
+    if (githubToken) {
+      env.GITHUB_TOKEN = githubToken;
+      logger.info('GitHub token configured for Git CLI operations');
+    } else {
+      logger.warn('No GitHub token available for Git CLI operations');
+    }
+  } catch (error) {
+    logger.error('Failed to obtain GitHub token for Git CLI:', error);
+  }
+
+  return env;
+}
+
+export async function getGitCommands(): Promise<{
+  gitPush: string;
+  gitPull: string;
+  gitClone: (repoUrl: string, directory?: string) => string;
+  gitRemoteSetUrl: (remoteName: string, url: string) => string;
+}> {
+  const env = await getGitEnvironmentVariables();
+  const tokenPrefix = env.GITHUB_TOKEN ? `GITHUB_TOKEN=${env.GITHUB_TOKEN} ` : '';
+
+  return {
+    gitPush: `${tokenPrefix}git push`,
+    gitPull: `${tokenPrefix}git pull`,
+    gitClone: (repoUrl: string, directory?: string) => 
+      `${tokenPrefix}git clone ${repoUrl}${directory ? ` ${directory}` : ''}`,
+    gitRemoteSetUrl: (remoteName: string, url: string) => 
+      `${tokenPrefix}git remote set-url ${remoteName} ${url}`,
+  };
+}
+
+export async function createGitCommand(command: string, useAuth: boolean = true): Promise<string> {
+  if (!useAuth) {
+    return command;
+  }
+
+  try {
+    const token = await getGitHubTokenForCLI();
+    if (token) {
+      return `GITHUB_TOKEN=${token} ${command}`;
+    }
+    return command;
+  } catch (error) {
+    logger.error('Failed to get GitHub token for Git command:', error);
+    return command;
+  }
+}

--- a/src/github-auth.ts
+++ b/src/github-auth.ts
@@ -1,0 +1,209 @@
+import jwt from 'jsonwebtoken';
+import { config } from './config.js';
+import { Logger } from './logger.js';
+
+const logger = new Logger('GitHubAuth');
+
+export interface GitHubAppConfig {
+  appId: string;
+  privateKey: string;
+  installationId?: string;
+}
+
+export class GitHubAppAuth {
+  private installationId?: number;
+  private installationTokenCache: {
+    token: string;
+    expiresAt: Date;
+  } | null = null;
+
+  constructor(private appConfig: GitHubAppConfig) {
+    if (appConfig.installationId) {
+      this.installationId = parseInt(appConfig.installationId, 10);
+    }
+  }
+
+  async getInstallationToken(installationId?: number): Promise<string> {
+    const targetInstallationId = installationId || this.installationId;
+    
+    if (!targetInstallationId) {
+      throw new Error('Installation ID is required. Either provide it as parameter or configure it in environment variables.');
+    }
+
+    if (this.installationTokenCache && this.installationTokenCache.expiresAt > new Date()) {
+      logger.info('Using cached GitHub App installation token');
+      return this.installationTokenCache.token;
+    }
+
+    try {
+      logger.info(`Generating GitHub App installation token for installation ${targetInstallationId}`);
+      
+      // Get a fresh installation token directly using the GitHub API
+      const appJWT = await this.getAppJWT();
+      const response = await fetch(`https://api.github.com/app/installations/${targetInstallationId}/access_tokens`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${appJWT}`,
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'Claude-Code-Slack-Bot/1.0.0',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      }
+
+      const tokenData = await response.json() as { token: string; expires_at: string };
+      const expiresAt = new Date(tokenData.expires_at);
+      
+      this.installationTokenCache = {
+        token: tokenData.token,
+        expiresAt,
+      };
+
+      logger.info(`GitHub App installation token generated, expires at ${expiresAt.toISOString()}`);
+      return tokenData.token;
+    } catch (error) {
+      logger.error('Failed to generate GitHub App installation token:', error);
+      throw new Error(`Failed to authenticate with GitHub App: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async getAppJWT(): Promise<string> {
+    try {
+      const now = Math.floor(Date.now() / 1000);
+      const payload = {
+        iat: now - 60,
+        exp: now + (10 * 60),
+        iss: this.appConfig.appId,
+      };
+
+      return jwt.sign(payload, this.appConfig.privateKey, { algorithm: 'RS256' });
+    } catch (error) {
+      logger.error('Failed to generate GitHub App JWT:', error);
+      throw new Error(`Failed to generate GitHub App JWT: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async listInstallations(): Promise<Array<{ id: number; account: { login: string; type: string } }>> {
+    try {
+      logger.info('Fetching GitHub App installations');
+      
+      const appJWT = await this.getAppJWT();
+      const response = await fetch('https://api.github.com/app/installations', {
+        headers: {
+          'Authorization': `Bearer ${appJWT}`,
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'Claude-Code-Slack-Bot/1.0.0',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      }
+
+      const installations = await response.json() as Array<{
+        id: number;
+        account: { login: string; type: string };
+      }>;
+      logger.info(`Found ${installations.length} GitHub App installations`);
+      
+      return installations.map((installation) => ({
+        id: installation.id,
+        account: {
+          login: installation.account.login,
+          type: installation.account.type,
+        },
+      }));
+    } catch (error) {
+      logger.error('Failed to list GitHub App installations:', error);
+      throw new Error(`Failed to list installations: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  invalidateTokenCache(): void {
+    logger.info('Invalidating GitHub App installation token cache');
+    this.installationTokenCache = null;
+  }
+}
+
+let githubAppAuth: GitHubAppAuth | null = null;
+
+export function getGitHubAppAuth(): GitHubAppAuth | null {
+  if (!config.github.appId || !config.github.privateKey) {
+    return null;
+  }
+
+  if (!githubAppAuth) {
+    githubAppAuth = new GitHubAppAuth({
+      appId: config.github.appId,
+      privateKey: config.github.privateKey,
+      installationId: config.github.installationId,
+    });
+  }
+
+  return githubAppAuth;
+}
+
+export function isGitHubAppConfigured(): boolean {
+  return !!(config.github.appId && config.github.privateKey);
+}
+
+export async function discoverInstallations(): Promise<void> {
+  const githubAuth = getGitHubAppAuth();
+  if (!githubAuth) {
+    logger.error('GitHub App not configured. Please set GITHUB_APP_ID and GITHUB_PRIVATE_KEY environment variables.');
+    return;
+  }
+
+  try {
+    const installations = await githubAuth.listInstallations();
+    
+    if (installations.length === 0) {
+      logger.info('No GitHub App installations found. Please install the app on at least one organization or repository.');
+      return;
+    }
+
+    logger.info('GitHub App installations found:');
+    installations.forEach((installation, index) => {
+      logger.info(`  ${index + 1}. ${installation.account.login} (${installation.account.type}) - ID: ${installation.id}`);
+    });
+
+    if (!config.github.installationId) {
+      logger.info('To use GitHub integration, set GITHUB_INSTALLATION_ID to one of the IDs above.');
+    } else {
+      const currentInstallation = installations.find(inst => inst.id.toString() === config.github.installationId);
+      if (currentInstallation) {
+        logger.info(`Currently configured for: ${currentInstallation.account.login} (${currentInstallation.account.type})`);
+      } else {
+        logger.warn(`Configured installation ID ${config.github.installationId} not found in available installations.`);
+      }
+    }
+  } catch (error) {
+    logger.error('Failed to discover GitHub App installations:', error);
+  }
+}
+
+export async function getGitHubTokenForCLI(): Promise<string | null> {
+  // First try to get the token from environment variable
+  if (config.github.token) {
+    logger.info('Using GITHUB_TOKEN from environment variables for Git CLI operations');
+    return config.github.token;
+  }
+
+  // If no environment token, try to get one from GitHub App
+  const githubAuth = getGitHubAppAuth();
+  if (githubAuth) {
+    try {
+      logger.info('Obtaining GitHub App installation token for Git CLI operations');
+      const token = await githubAuth.getInstallationToken();
+      return token;
+    } catch (error) {
+      logger.error('Failed to obtain GitHub App installation token:', error);
+      return null;
+    }
+  }
+
+  logger.warn('No GitHub authentication configured. Set GITHUB_TOKEN or configure GitHub App (GITHUB_APP_ID, GITHUB_PRIVATE_KEY, GITHUB_INSTALLATION_ID)');
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { ClaudeHandler } from './claude-handler';
 import { SlackHandler } from './slack-handler';
 import { McpManager } from './mcp-manager';
 import { Logger } from './logger';
+import { discoverInstallations, isGitHubAppConfigured } from './github-auth.js';
 
 const logger = new Logger('Main');
 
@@ -29,6 +30,11 @@ async function start() {
     // Initialize MCP manager
     const mcpManager = new McpManager();
     const mcpConfig = mcpManager.loadConfiguration();
+
+    // Discover GitHub App installations if configured
+    if (isGitHubAppConfigured()) {
+      await discoverInstallations();
+    }
     
     // Initialize handlers
     const claudeHandler = new ClaudeHandler(mcpManager);

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -1,0 +1,255 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { StderrLogger } from './stderr-logger.js';
+
+const logger = new StderrLogger('SharedStore');
+
+export interface PermissionResponse {
+  behavior: 'allow' | 'deny';
+  updatedInput?: any;
+  message?: string;
+}
+
+export interface PendingApproval {
+  tool_name: string;
+  input: any;
+  channel?: string;
+  thread_ts?: string;
+  user?: string;
+  created_at: number;
+  expires_at: number;
+}
+
+/**
+ * File-based shared store for inter-process communication
+ * between the permission MCP server and Slack handler
+ */
+export class SharedStore {
+  private storeDir: string;
+  private pendingDir: string;
+  private responseDir: string;
+
+  constructor() {
+    // Use OS temp directory for cross-process communication
+    this.storeDir = path.join(os.tmpdir(), 'claude-code-slack-bot-store');
+    this.pendingDir = path.join(this.storeDir, 'pending');
+    this.responseDir = path.join(this.storeDir, 'responses');
+    
+    this.ensureDirectories();
+  }
+
+  private ensureDirectories() {
+    try {
+      if (!fs.existsSync(this.storeDir)) {
+        fs.mkdirSync(this.storeDir, { recursive: true });
+      }
+      if (!fs.existsSync(this.pendingDir)) {
+        fs.mkdirSync(this.pendingDir, { recursive: true });
+      }
+      if (!fs.existsSync(this.responseDir)) {
+        fs.mkdirSync(this.responseDir, { recursive: true });
+      }
+    } catch (error) {
+      logger.error('Failed to create store directories:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Store a pending approval request
+   */
+  async storePendingApproval(approvalId: string, approval: PendingApproval): Promise<void> {
+    const filePath = path.join(this.pendingDir, `${approvalId}.json`);
+    try {
+      await fs.promises.writeFile(filePath, JSON.stringify(approval, null, 2));
+      logger.debug('Stored pending approval', { approvalId, filePath });
+    } catch (error) {
+      logger.error('Failed to store pending approval:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a pending approval request
+   */
+  async getPendingApproval(approvalId: string): Promise<PendingApproval | null> {
+    const filePath = path.join(this.pendingDir, `${approvalId}.json`);
+    try {
+      if (!fs.existsSync(filePath)) {
+        return null;
+      }
+      
+      const data = await fs.promises.readFile(filePath, 'utf8');
+      const approval = JSON.parse(data) as PendingApproval;
+      
+      // Check if expired
+      if (Date.now() > approval.expires_at) {
+        await this.deletePendingApproval(approvalId);
+        return null;
+      }
+      
+      return approval;
+    } catch (error) {
+      logger.error('Failed to get pending approval:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Store a permission response
+   */
+  async storePermissionResponse(approvalId: string, response: PermissionResponse): Promise<void> {
+    const filePath = path.join(this.responseDir, `${approvalId}.json`);
+    try {
+      await fs.promises.writeFile(filePath, JSON.stringify(response, null, 2));
+      logger.debug('Stored permission response', { approvalId, response: response.behavior });
+    } catch (error) {
+      logger.error('Failed to store permission response:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Wait for a permission response with polling
+   */
+  async waitForPermissionResponse(approvalId: string, timeoutMs: number = 5 * 60 * 1000): Promise<PermissionResponse> {
+    const filePath = path.join(this.responseDir, `${approvalId}.json`);
+    const startTime = Date.now();
+    const pollInterval = 500; // 500ms polling interval
+    
+    return new Promise((resolve, reject) => {
+      const poll = async () => {
+        try {
+          // Check for timeout
+          if (Date.now() - startTime > timeoutMs) {
+            await this.cleanup(approvalId);
+            resolve({
+              behavior: 'deny',
+              message: 'Permission request timed out'
+            });
+            return;
+          }
+
+          // Check if response exists
+          if (fs.existsSync(filePath)) {
+            const data = await fs.promises.readFile(filePath, 'utf8');
+            const response = JSON.parse(data) as PermissionResponse;
+            
+            // Cleanup files
+            await this.cleanup(approvalId);
+            
+            resolve(response);
+            return;
+          }
+
+          // Continue polling
+          setTimeout(poll, pollInterval);
+        } catch (error) {
+          logger.error('Error during polling:', error);
+          await this.cleanup(approvalId);
+          reject(error);
+        }
+      };
+
+      poll();
+    });
+  }
+
+  /**
+   * Delete a pending approval
+   */
+  async deletePendingApproval(approvalId: string): Promise<void> {
+    const filePath = path.join(this.pendingDir, `${approvalId}.json`);
+    try {
+      if (fs.existsSync(filePath)) {
+        await fs.promises.unlink(filePath);
+        logger.debug('Deleted pending approval', { approvalId });
+      }
+    } catch (error) {
+      logger.error('Failed to delete pending approval:', error);
+    }
+  }
+
+  /**
+   * Clean up all files for an approval ID
+   */
+  async cleanup(approvalId: string): Promise<void> {
+    await Promise.all([
+      this.deletePendingApproval(approvalId),
+      this.deletePermissionResponse(approvalId)
+    ]);
+  }
+
+  /**
+   * Delete a permission response
+   */
+  async deletePermissionResponse(approvalId: string): Promise<void> {
+    const filePath = path.join(this.responseDir, `${approvalId}.json`);
+    try {
+      if (fs.existsSync(filePath)) {
+        await fs.promises.unlink(filePath);
+        logger.debug('Deleted permission response', { approvalId });
+      }
+    } catch (error) {
+      logger.error('Failed to delete permission response:', error);
+    }
+  }
+
+  /**
+   * Clean up expired approvals
+   */
+  async cleanupExpired(): Promise<number> {
+    let cleaned = 0;
+    try {
+      const pendingFiles = await fs.promises.readdir(this.pendingDir);
+      
+      for (const fileName of pendingFiles) {
+        if (!fileName.endsWith('.json')) continue;
+        
+        const approvalId = fileName.replace('.json', '');
+        const approval = await this.getPendingApproval(approvalId);
+        
+        if (!approval) {
+          // File was already cleaned up by getPendingApproval if expired
+          cleaned++;
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to cleanup expired approvals:', error);
+    }
+    
+    return cleaned;
+  }
+
+  /**
+   * Get count of pending approvals
+   */
+  async getPendingCount(): Promise<number> {
+    try {
+      const files = await fs.promises.readdir(this.pendingDir);
+      return files.filter(f => f.endsWith('.json')).length;
+    } catch (error) {
+      logger.error('Failed to get pending count:', error);
+      return 0;
+    }
+  }
+
+  /**
+   * List all pending approval IDs
+   */
+  async listPendingApprovalIds(): Promise<string[]> {
+    try {
+      const files = await fs.promises.readdir(this.pendingDir);
+      return files
+        .filter(f => f.endsWith('.json'))
+        .map(f => f.replace('.json', ''));
+    } catch (error) {
+      logger.error('Failed to list pending approval IDs:', error);
+      return [];
+    }
+  }
+}
+
+// Singleton instance
+export const sharedStore = new SharedStore();

--- a/src/slack-handler.ts
+++ b/src/slack-handler.ts
@@ -123,8 +123,9 @@ export class SlackHandler {
 
     // Check if this is an MCP info command (only if there's text)
     if (text && this.isMcpInfoCommand(text)) {
+      const mcpInfo = await this.mcpManager.formatMcpInfo();
       await say({
-        text: this.mcpManager.formatMcpInfo(),
+        text: mcpInfo,
         thread_ts: thread_ts || ts,
       });
       return;
@@ -134,8 +135,9 @@ export class SlackHandler {
     if (text && this.isMcpReloadCommand(text)) {
       const reloaded = this.mcpManager.reloadConfiguration();
       if (reloaded) {
+        const mcpInfo = await this.mcpManager.formatMcpInfo();
         await say({
-          text: `✅ MCP configuration reloaded successfully.\n\n${this.mcpManager.formatMcpInfo()}`,
+          text: `✅ MCP configuration reloaded successfully.\n\n${mcpInfo}`,
           thread_ts: thread_ts || ts,
         });
       } else {

--- a/src/slack-handler.ts
+++ b/src/slack-handler.ts
@@ -6,7 +6,7 @@ import { WorkingDirectoryManager } from './working-directory-manager';
 import { FileHandler, ProcessedFile } from './file-handler';
 import { TodoManager, Todo } from './todo-manager';
 import { McpManager } from './mcp-manager';
-import { permissionServer } from './permission-mcp-server';
+import { sharedStore, PermissionResponse } from './shared-store';
 import { config } from './config';
 
 interface MessageEvent {
@@ -235,7 +235,7 @@ export class SlackHandler {
       statusMessageTs = statusResult.ts;
 
       // Add thinking reaction to original message (but don't spam if already set)
-      await this.updateMessageReaction(sessionKey, '🤔');
+      await this.updateMessageReaction(sessionKey, 'thinking_face');
       
       // Create Slack context for permission prompts
       const slackContext = {
@@ -268,7 +268,7 @@ export class SlackHandler {
             }
 
             // Update reaction to show working
-            await this.updateMessageReaction(sessionKey, '⚙️');
+            await this.updateMessageReaction(sessionKey, 'gear');
 
             // Check for TodoWrite tool and handle it specially
             const todoTool = message.message.content?.find((part: any) => 
@@ -332,7 +332,7 @@ export class SlackHandler {
       }
 
       // Update reaction to show completion
-      await this.updateMessageReaction(sessionKey, '✅');
+      await this.updateMessageReaction(sessionKey, 'white_check_mark');
 
       this.logger.info('Completed processing message', {
         sessionKey,
@@ -357,7 +357,7 @@ export class SlackHandler {
         }
 
         // Update reaction to show error
-        await this.updateMessageReaction(sessionKey, '❌');
+        await this.updateMessageReaction(sessionKey, 'x');
         
         await say({
           text: `Error: ${error.message || 'Something went wrong'}`,
@@ -376,7 +376,7 @@ export class SlackHandler {
         }
 
         // Update reaction to show cancellation
-        await this.updateMessageReaction(sessionKey, '⏹️');
+        await this.updateMessageReaction(sessionKey, 'stop_sign');
       }
 
       // Clean up temporary files in case of error too
@@ -436,6 +436,9 @@ export class SlackHandler {
           case 'TodoWrite':
             // Handle TodoWrite separately - don't include in regular tool output
             return this.handleTodoWrite(input);
+          case 'mcp__permission-prompt__permission_prompt':
+            // Don't show permission prompt tool usage - it's handled internally
+            return '';
           default:
             parts.push(this.formatGenericTool(toolName, input));
         }
@@ -633,11 +636,11 @@ export class SlackHandler {
 
     let emoji: string;
     if (completed === total) {
-      emoji = '✅'; // All tasks completed
+      emoji = 'white_check_mark'; // All tasks completed
     } else if (inProgress > 0) {
-      emoji = '🔄'; // Tasks in progress
+      emoji = 'arrows_counterclockwise'; // Tasks in progress
     } else {
-      emoji = '📋'; // Tasks pending
+      emoji = 'clipboard'; // Tasks pending
     }
 
     await this.updateMessageReaction(sessionKey, emoji);
@@ -752,29 +755,83 @@ export class SlackHandler {
     // Handle permission approval button clicks
     this.app.action('approve_tool', async ({ ack, body, respond }) => {
       await ack();
-      const approvalId = (body as any).actions[0].value;
-      this.logger.info('Tool approval granted', { approvalId });
       
-      permissionServer.resolveApproval(approvalId, true);
-      
-      await respond({
-        response_type: 'ephemeral',
-        text: '✅ Tool execution approved'
-      });
+      try {
+        const approvalId = (body as any).actions[0].value;
+        const user = (body as any).user?.id;
+        const triggerId = (body as any).trigger_id;
+        
+        this.logger.info('Tool approval granted', { 
+          approvalId, 
+          user,
+          triggerId 
+        });
+        
+        // Resolve the approval via shared store
+        const response: PermissionResponse = {
+          behavior: 'allow',
+          message: 'Approved by user'
+        };
+        await sharedStore.storePermissionResponse(approvalId, response);
+        
+        // Provide immediate feedback
+        await respond({
+          response_type: 'ephemeral',
+          text: '✅ Tool execution approved. Claude will now proceed with the operation.',
+          replace_original: false
+        });
+        
+        this.logger.debug('Approval processed successfully', { approvalId });
+      } catch (error) {
+        this.logger.error('Error processing tool approval', error);
+        
+        await respond({
+          response_type: 'ephemeral',
+          text: '❌ Error processing approval. The request may have already been handled.',
+          replace_original: false
+        });
+      }
     });
 
     // Handle permission denial button clicks
     this.app.action('deny_tool', async ({ ack, body, respond }) => {
       await ack();
-      const approvalId = (body as any).actions[0].value;
-      this.logger.info('Tool approval denied', { approvalId });
       
-      permissionServer.resolveApproval(approvalId, false);
-      
-      await respond({
-        response_type: 'ephemeral',
-        text: '❌ Tool execution denied'
-      });
+      try {
+        const approvalId = (body as any).actions[0].value;
+        const user = (body as any).user?.id;
+        const triggerId = (body as any).trigger_id;
+        
+        this.logger.info('Tool approval denied', { 
+          approvalId, 
+          user,
+          triggerId 
+        });
+        
+        // Resolve the denial via shared store
+        const response: PermissionResponse = {
+          behavior: 'deny',
+          message: 'Denied by user'
+        };
+        await sharedStore.storePermissionResponse(approvalId, response);
+        
+        // Provide immediate feedback
+        await respond({
+          response_type: 'ephemeral',
+          text: '❌ Tool execution denied. Claude will not proceed with this operation.',
+          replace_original: false
+        });
+        
+        this.logger.debug('Denial processed successfully', { approvalId });
+      } catch (error) {
+        this.logger.error('Error processing tool denial', error);
+        
+        await respond({
+          response_type: 'ephemeral',
+          text: '❌ Error processing denial. The request may have already been handled.',
+          replace_original: false
+        });
+      }
     });
 
     // Cleanup inactive sessions periodically

--- a/src/stderr-logger.ts
+++ b/src/stderr-logger.ts
@@ -1,0 +1,48 @@
+export interface LoggerInterface {
+  debug(message: string, data?: any): void;
+  info(message: string, data?: any): void;
+  warn(message: string, data?: any): void;
+  error(message: string, error?: any): void;
+}
+
+export class StderrLogger implements LoggerInterface {
+  private context: string;
+
+  constructor(context: string) {
+    this.context = context;
+  }
+
+  private formatMessage(level: string, message: string, data?: any): string {
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}] [${level}] [${this.context}]`;
+    
+    if (data) {
+      return `${prefix} ${message}\n${JSON.stringify(data, null, 2)}`;
+    }
+    return `${prefix} ${message}`;
+  }
+
+  debug(message: string, data?: any) {
+    // Only output debug messages if DEBUG environment variable is set
+    if (process.env.DEBUG) {
+      process.stderr.write(this.formatMessage('DEBUG', message, data) + '\n');
+    }
+  }
+
+  info(message: string, data?: any) {
+    process.stderr.write(this.formatMessage('INFO', message, data) + '\n');
+  }
+
+  warn(message: string, data?: any) {
+    process.stderr.write(this.formatMessage('WARN', message, data) + '\n');
+  }
+
+  error(message: string, error?: any) {
+    const errorData = error instanceof Error ? {
+      errorMessage: error.message,
+      stack: error.stack,
+      ...error
+    } : error;
+    process.stderr.write(this.formatMessage('ERROR', message, errorData) + '\n');
+  }
+}

--- a/src/working-directory-manager.ts
+++ b/src/working-directory-manager.ts
@@ -62,6 +62,7 @@ export class WorkingDirectoryManager {
   }
 
   private resolveDirectory(directory: string): string | null {
+    this.logger.debug('Resolving directory', { input: directory });
     // If it's an absolute path, use it directly
     if (path.isAbsolute(directory)) {
       if (fs.existsSync(directory)) {
@@ -80,6 +81,26 @@ export class WorkingDirectoryManager {
           resolved: baseRelativePath 
         });
         return path.resolve(baseRelativePath);
+      } else {
+        this.logger.debug('Directory not found relative to base, checking if it can be created', { 
+          input: directory,
+          baseDirectory: config.baseDirectory,
+          attemptedPath: baseRelativePath 
+        });
+        try {
+          fs.mkdirSync(baseRelativePath, { recursive: true });
+          this.logger.info('Created directory relative to base directory', { 
+            input: directory,
+            baseDirectory: config.baseDirectory,
+            resolved: baseRelativePath 
+          });
+          return path.resolve(baseRelativePath);
+        } catch (error) {
+          this.logger.error('Failed to create directory relative to base', { 
+            path: baseRelativePath,
+            error 
+          });
+        }
       }
     }
 

--- a/src/working-directory-manager.ts
+++ b/src/working-directory-manager.ts
@@ -93,6 +93,21 @@ export class WorkingDirectoryManager {
       return cwdRelativePath;
     }
 
+    // If directory doesn't exist, try to create it
+    try {
+      fs.mkdirSync(cwdRelativePath, { recursive: true });
+      this.logger.info('Created directory relative to cwd', { 
+        input: directory,
+        resolved: cwdRelativePath 
+      });
+      return cwdRelativePath;
+    } catch (error) {
+      this.logger.error('Failed to create directory', { 
+        path: cwdRelativePath,
+        error 
+      });
+    }
+
     return null;
   }
 

--- a/test-token-refresh.js
+++ b/test-token-refresh.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+// Test script for GitHub App token refresh functionality
+// This script tests the token refresh mechanism without requiring a full Slack setup
+
+import { config, validateConfig } from './dist/config.js';
+import { getGitHubAppAuth, isGitHubAppConfigured } from './dist/github-auth.js';
+import { Logger } from './dist/logger.js';
+
+const logger = new Logger('TokenRefreshTest');
+
+async function testTokenRefresh() {
+  try {
+    logger.info('🧪 Testing GitHub App token refresh functionality...');
+
+    // Check if GitHub App is configured
+    if (!isGitHubAppConfigured()) {
+      logger.warn('❌ GitHub App not configured. Please set GITHUB_APP_ID, GITHUB_PRIVATE_KEY, and GITHUB_INSTALLATION_ID environment variables.');
+      process.exit(1);
+    }
+
+    const githubAuth = getGitHubAppAuth();
+    if (!githubAuth) {
+      logger.error('❌ Failed to get GitHub App auth instance');
+      process.exit(1);
+    }
+
+    logger.info('✅ GitHub App configuration found');
+
+    // Test getting initial token
+    logger.info('🔄 Testing initial token generation...');
+    const initialToken = await githubAuth.getInstallationToken();
+    logger.info(`✅ Initial token generated successfully (length: ${initialToken.length})`);
+
+    // Start auto-refresh
+    logger.info('🔄 Testing auto-refresh startup...');
+    await githubAuth.startAutoRefresh();
+    logger.info('✅ Auto-refresh started successfully');
+
+    // Test manual token refresh (this should use cached token)
+    logger.info('🔄 Testing cached token retrieval...');
+    const cachedToken = await githubAuth.getInstallationToken();
+    logger.info(`✅ Cached token retrieved successfully (matches initial: ${cachedToken === initialToken})`);
+
+    // Test invalidation and refresh
+    logger.info('🔄 Testing token cache invalidation and refresh...');
+    githubAuth.invalidateTokenCache();
+    const refreshedToken = await githubAuth.getInstallationToken();
+    logger.info(`✅ Token refreshed after invalidation (new token: ${refreshedToken !== initialToken})`);
+
+    // Stop auto-refresh
+    logger.info('🔄 Testing auto-refresh cleanup...');
+    githubAuth.stopAutoRefresh();
+    logger.info('✅ Auto-refresh stopped successfully');
+
+    logger.info('🎉 All tests passed! Token refresh functionality is working correctly.');
+
+    // Test environment variable is set
+    if (process.env.GITHUB_TOKEN) {
+      logger.info(`✅ GITHUB_TOKEN environment variable is set (length: ${process.env.GITHUB_TOKEN.length})`);
+    } else {
+      logger.warn('⚠️ GITHUB_TOKEN environment variable is not set');
+    }
+
+  } catch (error) {
+    logger.error('❌ Test failed:', error);
+    process.exit(1);
+  }
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', () => {
+  logger.info('Test interrupted, cleaning up...');
+  const githubAuth = getGitHubAppAuth();
+  if (githubAuth) {
+    githubAuth.stopAutoRefresh();
+  }
+  process.exit(0);
+});
+
+// Run the test
+testTokenRefresh();


### PR DESCRIPTION
## Problem

The permission MCP server path was hardcoded to the original developer's local machine path (`/Users/marcelpociot/Experiments/claude-code-slack/src/permission-mcp-server.ts`), which causes the permission server to fail on any other system.

## Solution

Changed to use `path.join(__dirname, 'permission-mcp-server.ts')` to dynamically resolve the path relative to the current module location.

## Changes
- Added imports for `path` and `fileURLToPath`
- Defined `__filename` and `__dirname` for ES modules
- Replaced hardcoded path with dynamic path resolution

This ensures the permission server can be found and started correctly regardless of where the project is installed.

## Testing
The permission server will now correctly resolve to the local installation path instead of looking for a non-existent hardcoded path.